### PR TITLE
Moved Sample_Input/Output to ENP_FILES

### DIFF
--- a/ANALYSIS_TEMPLATE/ANALYSIS_COMPARE.m
+++ b/ANALYSIS_TEMPLATE/ANALYSIS_COMPARE.m
@@ -53,15 +53,18 @@ end
 %---------------------------------------------------------------------
 % 2. Set Location of Common Data and observed matlab data inputfiles
 %---------------------------------------------------------------------
-INI.DATA_COMMON = '..\..\ENP_TOOLS_Sample_Input\Data_Common/'; 
+INI.DATA_COMMON = '..\..\ENP_FILES\ENP_TOOLS_Sample_Input\Data_Common/'; 
 
 INI.FILE_OBSERVED = [INI.DATA_COMMON '/M06_OBSERVED_DATA_test.MATLAB'];
 
 %---------------------------------------------------------------------
 % 3. Set location to read inputfiles containing computed Matlab data
 %---------------------------------------------------------------------
-INI.DATA_COMPUTED = '..\..\ENP_TOOLS_Sample_Input\Model_Output_Processed/';
-%INI.DATA_COMPUTED = '..\..\ENP_TOOLS_Sample_Output\generateComputedMatlab_output/';
+% use this for unit testing
+INI.DATA_COMPUTED = '..\..\ENP_FILES\ENP_TOOLS_Sample_Input\Model_Output_Processed\';
+
+% use this for sequential testing
+%INI.DATA_COMPUTED = '..\..\ENP_TOOLS_Output_Sequential\Model_Output_Processed\';
 
 %---------------------------------------------------------------------
 % 4. Set a tag for this analysis
@@ -69,7 +72,13 @@ INI.DATA_COMPUTED = '..\..\ENP_TOOLS_Sample_Input\Model_Output_Processed/';
 %      output datasets, and other filenames)
 %---------------------------------------------------------------------
 INI.ANALYSIS_TAG = 'M01-M06_test';
-INI.POST_PROC_DIR = ['..\..\ENP_TOOLS_Sample_Output\ANALYSIS_COMPARE_output\' INI.ANALYSIS_TAG '/'];
+%INI.ANALYSIS_TAG = 'M01-M06_test_short';
+
+% use this for unit testing
+INI.POST_PROC_DIR = ['..\..\ENP_TOOLS_Output\ANALYSIS_COMPARE_output\' INI.ANALYSIS_TAG '/'];
+
+% use this for sequential testing
+%INI.POST_PROC_DIR = ['..\..\ENP_TOOLS_Output_Sequential\ANALYSIS_COMPARE_output\' INI.ANALYSIS_TAG '/'];
 
 %---------------------------------------------------------------------
 % 5. Choose simulations to be analyzed (must be present in INI.DATA_COMPUTED

--- a/ANALYSIS_TEMPLATE/generateComputedMatlab.m
+++ b/ANALYSIS_TEMPLATE/generateComputedMatlab.m
@@ -48,12 +48,16 @@ INI = initializeLIB(INI);
 %---------------------------------------------------------------------
 % 2. Set Location of Common Data  
 %---------------------------------------------------------------------
-INI.DATA_COMMON = '..\..\ENP_TOOLS_Sample_Input\Data_Common/'; 
+INI.DATA_COMMON = '..\..\ENP_FILES\ENP_TOOLS_Sample_Input\Data_Common/'; 
 
 %---------------------------------------------------------------------
 % 3. Set location to store computed Matlab datafile for each simulation
 %---------------------------------------------------------------------
-INI.DATA_COMPUTED = '..\..\ENP_TOOLS_Sample_Output\generateComputedMatlab_output/';
+% use this for unit testing
+INI.DATA_COMPUTED = '..\..\ENP_TOOLS_Output\generateComputedMatlab_output\Model_Output_Processed\';
+
+% use this for sequential testing
+%INI.DATA_COMPUTED = '..\..\ENP_TOOLS_Output_Sequential\Model_Output_Processed\';
 
 %---------------------------------------------------------------------
 % 4. Provide name of the Excel file with all stations (and data items):
@@ -73,10 +77,10 @@ INI.CONVERT_M11CHAINAGES = 1.0;     % use 1.0 if Excel file chainages in feet an
 % Once data are extracted, simulation files may be deleted
 
 i = 0;
-i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_TOOLS_Sample_Input\Result\', 'M01','_', 'test'];
-i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_TOOLS_Sample_Input\Result\', 'M06','_', 'test'];
-%i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_TOOLS_Sample_Input\Result\', 'M01','_', 'test_short'];
-%i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_TOOLS_Sample_Input\Result\', 'M06','_', 'test_short'];
+i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_FILES\ENP_TOOLS_Sample_Input\Result\', 'M01','_', 'test'];
+i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_FILES\ENP_TOOLS_Sample_Input\Result\', 'M06','_', 'test'];
+%i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_FILES\ENP_TOOLS_Sample_Input\Result\', 'M01','_', 'test_short'];
+%i = i + 1;  INI.MODEL_SIMULATION_SET{i} = ['..\..\ENP_FILES\ENP_TOOLS_Sample_Input\Result\', 'M06','_', 'test_short'];
 
 %---------------------------------------------------------------------
 % 6. Process transects

--- a/PRE_PROCESSING/D00_dfe_STATION_DATA.m
+++ b/PRE_PROCESSING/D00_dfe_STATION_DATA.m
@@ -1,4 +1,7 @@
 function D00_dfe_STATION_DATA()
+
+fprintf('\n *** THIS SCRIPT IS CURRENTLY NOT WORKING ***\n\n');
+
 % This script creates a container (MAP_STATIONS) with the structure 
 % (STATIONS); takes the station name (NAME), longitude (X), latitude (Y) 
 % from the input file (station_data_from_dataforever.txt), and an 

--- a/PRE_PROCESSING/D01_convert_DFE_to_DFS0.m
+++ b/PRE_PROCESSING/D01_convert_DFE_to_DFS0.m
@@ -27,24 +27,39 @@ function D01_convert_DFE_to_DFS0()
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------
 
+% -------------------------------------------------------------------------
+% Location of input files
+% -------------------------------------------------------------------------
+
 % Location of raw DFE measurement files (flow and stage in separate folders, one station per file)
-INI.OBS_FLOW_DFE_DIR  = '../../ENP_TOOLS_Sample_Input/Raw_DFE_Data/Flow/';
-INI.OBS_STAGE_DFE_DIR = '../../ENP_TOOLS_Sample_Input/Raw_DFE_Data/Stage/';
+INI.OBS_FLOW_DFE_DIR  = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Raw_DFE_Data/Flow/';
+INI.OBS_STAGE_DFE_DIR = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Raw_DFE_Data/Stage/';
 
 % Suffix of raw DFE data files (used to generate a list of files to process)
 INI.OBS_DFE_FILETYPE = '*.dat';
 
 % Location of station metadata file (this is the DFE station table)
-DFE_STATION_DATA_FILE = '../../ENP_TOOLS_Sample_Input/Data_Common/dfe_station_table.txt';
+DFE_STATION_DATA_FILE = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Data_Common/dfe_station_table.txt';
 
+% -------------------------------------------------------------------------
 % Location of dfs0 output files (each datatype needs a separate folder)
-INI.DIR_FLOW_DFS0     = '../../ENP_TOOLS_Sample_Input/Obs_Data_Processed/FLOW/DFS0/';
-INI.DIR_STAGE_DFS0    = '../../ENP_TOOLS_Sample_Input/Obs_Data_Processed/STAGE/DFS0/';
+% -------------------------------------------------------------------------
+% use these for unit testing
+INI.DIR_FLOW_DFS0     = '../../ENP_TOOLS_Output/D01_convert_DFE_to_DFS0_output/Obs_Data_Processed/FLOW/DFS0/';
+INI.DIR_STAGE_DFS0    = '../../ENP_TOOLS_Output/D01_convert_DFE_to_DFS0_output/Obs_Data_Processed/STAGE/DFS0/';
 
+% use these for sequential testing
+%INI.DIR_FLOW_DFS0     = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/FLOW/DFS0/';
+%INI.DIR_STAGE_DFS0    = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/STAGE/DFS0/';
+
+% -------------------------------------------------------------------------
 % Location of ENPMS library
+% -------------------------------------------------------------------------
 INI.MATLAB_SCRIPTS = '../ENPMS/';
 
+% -------------------------------------------------------------------------
 % Other options (0 = NO, 1 = YES)
+% -------------------------------------------------------------------------
 INI.DEBUG = 0;                 % Print extra debugging output?
 INI.DELETE_EXISTING_DFS0 = 1;  % Delete existing DFS0 files? Has this option been checked?
 

--- a/PRE_PROCESSING/D02_analysis_DFS0_Q.m
+++ b/PRE_PROCESSING/D02_analysis_DFS0_Q.m
@@ -8,35 +8,52 @@ function D02_analysis_DFS0_Q()
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------
 
+% -------------------------------------------------------------------------
 % Location of dfs0 FLOW files 
-INI.DIR_FILES           = '../../ENP_TOOLS_Sample_Input/Obs_Data_Processed/FLOW/';
+% -------------------------------------------------------------------------
+% use these for unit testing
+INI.DIR_INFILES         = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Obs_Data_Processed/FLOW/';
+INI.DIR_OUTFILES        = '../../ENP_TOOLS_Output/D02_analysis_DFS0_Q_output/Obs_Data_Processed/FLOW/';
 
-INI.DIR_FLOW_DFS0       = [INI.DIR_FILES 'DFS0/'];
-INI.DIR_FLOW_PNGS       = [INI.DIR_FILES 'DFS0_pngs/'];
-INI.FLOW_LATEX_FILENAME = [INI.DIR_FILES 'FLOW.tex'];
+% use these for sequential testing
+%INI.DIR_INFILES         = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/FLOW/';
+%INI.DIR_OUTFILES        = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/FLOW/';
+
+% -------------------------------------------------------------------------
+% Set up directory structure (this shouldn't need changing)
+% -------------------------------------------------------------------------
+INI.DIR_FLOW_DFS0       = [INI.DIR_INFILES 'DFS0/'];
+INI.DIR_FLOW_PNGS       = [INI.DIR_OUTFILES 'DFS0_pngs/'];
+INI.FLOW_LATEX_FILENAME = [INI.DIR_OUTFILES 'FLOW.tex'];
 INI.FLOW_LATEX_HEADER   = 'FLOW Analysis *New';    % header printed in LaTeX document
 INI.FLOW_LATEX_RELATIVE_PNG_PATH = './DFS0_pngs/'; % RELATIVE path from location of .tex file to location of .png files
 
-INI.DIR_FLOW_DFS0DD       = [INI.DIR_FILES 'DFS0DD/'];
-INI.DIR_FLOW_PNGSDD       = [INI.DIR_FILES 'DFS0DD_pngs/'];
-INI.FLOWDD_LATEX_FILENAME = [INI.DIR_FILES 'FLOW_DD.tex'];
+INI.DIR_FLOW_DFS0DD       = [INI.DIR_OUTFILES 'DFS0DD/'];
+INI.DIR_FLOW_PNGSDD       = [INI.DIR_OUTFILES 'DFS0DD_pngs/'];
+INI.FLOWDD_LATEX_FILENAME = [INI.DIR_OUTFILES 'FLOW_DD.tex'];
 INI.FLOWDD_LATEX_HEADER   = 'FLOW Analysis Daily *New';
 INI.FLOWDD_LATEX_RELATIVE_PNG_PATH = './DFS0DD_pngs/';
 
-INI.DIR_FLOW_DFS0HR       = [INI.DIR_FILES 'DFS0HR/'];
-INI.DIR_FLOW_PNGSHR       = [INI.DIR_FILES 'DFS0HR_pngs/'];
-INI.FLOWHR_LATEX_FILENAME = [INI.DIR_FILES 'FLOW_HR.tex'];
+INI.DIR_FLOW_DFS0HR       = [INI.DIR_OUTFILES 'DFS0HR/'];
+INI.DIR_FLOW_PNGSHR       = [INI.DIR_OUTFILES 'DFS0HR_pngs/'];
+INI.FLOWHR_LATEX_FILENAME = [INI.DIR_OUTFILES 'FLOW_HR.tex'];
 INI.FLOWHR_LATEX_HEADER   = 'FLOW Analysis Hourly *New';
 INI.FLOWHR_LATEX_RELATIVE_PNG_PATH = './DFS0HR_pngs/';
 
+% -------------------------------------------------------------------------
 % Location of ENPMS library
+% -------------------------------------------------------------------------
 INI.MATLAB_SCRIPTS = '../ENPMS/';
 
+% -------------------------------------------------------------------------
 % Other options (0 = NO, 1 = YES)
+% -------------------------------------------------------------------------
 INI.DELETE_EXISTING_DFS0 = 1; 
 
+% -------------------------------------------------------------------------
 % Location of blank figure
-INI.BLANK_PNG = '../../ENP_TOOLS_Sample_Input/Data_Common/blank.png';
+% -------------------------------------------------------------------------
+INI.BLANK_PNG = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Data_Common/blank.png';
 
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------

--- a/PRE_PROCESSING/D03_analysis_DFS0_H.m
+++ b/PRE_PROCESSING/D03_analysis_DFS0_H.m
@@ -8,36 +8,53 @@ function D03_analysis_DFS0_H()
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------
 
+% -------------------------------------------------------------------------
 % Location of dfs0 STAGE files 
-INI.DIR_FILES           = '../../ENP_TOOLS_Sample_Input/Obs_Data_Processed/STAGE/';
+% -------------------------------------------------------------------------
+% use these for unit testing
+INI.DIR_INFILES          = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Obs_Data_Processed/STAGE/';
+INI.DIR_OUTFILES         = '../../ENP_TOOLS_Output/D03_analysis_DFS0_H_output/Obs_Data_Processed/STAGE/';
 
-INI.DIR_STAGE_DFS0       = [INI.DIR_FILES 'DFS0/'];
-INI.DIR_STAGE_PNGS       = [INI.DIR_FILES 'DFS0_pngs/'];
-INI.STAGE_LATEX_FILENAME = [INI.DIR_FILES 'STAGE.tex'];
+% use these for sequential testing
+%INI.DIR_INFILES         = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/STAGE/';
+%INI.DIR_OUTFILES        = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/STAGE/';
+
+% -------------------------------------------------------------------------
+% Set up directory structure (this shouldn't need changing)
+% -------------------------------------------------------------------------
+INI.DIR_STAGE_DFS0       = [INI.DIR_INFILES 'DFS0/'];
+INI.DIR_STAGE_PNGS       = [INI.DIR_OUTFILES 'DFS0_pngs/'];
+INI.STAGE_LATEX_FILENAME = [INI.DIR_OUTFILES 'STAGE.tex'];
 INI.STAGE_LATEX_HEADER   = 'Water Level Statistics';    % header printed in LaTeX document
 INI.STAGE_LATEX_RELATIVE_PNG_PATH = './DFS0_pngs/'; % RELATIVE path from location of .tex file to location of .png files
 
-INI.DIR_STAGE_DFS0DD       = [INI.DIR_FILES 'DFS0DD/'];
-INI.DIR_STAGE_PNGSDD       = [INI.DIR_FILES 'DFS0DD_pngs/'];
-INI.STAGEDD_LATEX_FILENAME = [INI.DIR_FILES 'STAGE_DD.tex'];
+INI.DIR_STAGE_DFS0DD       = [INI.DIR_OUTFILES 'DFS0DD/'];
+INI.DIR_STAGE_PNGSDD       = [INI.DIR_OUTFILES 'DFS0DD_pngs/'];
+INI.STAGEDD_LATEX_FILENAME = [INI.DIR_OUTFILES 'STAGE_DD.tex'];
 INI.STAGEDD_LATEX_HEADER   = 'Daily Water Level Statistics';
 INI.STAGEDD_LATEX_RELATIVE_PNG_PATH = './DFS0DD_pngs/';
 
-INI.DIR_STAGE_DFS0HR       = [INI.DIR_FILES 'DFS0HR/'];
-INI.DIR_STAGE_PNGSHR       = [INI.DIR_FILES 'DFS0HR_pngs/'];
-INI.STAGEHR_LATEX_FILENAME = [INI.DIR_FILES 'STAGE_HR.tex'];
+INI.DIR_STAGE_DFS0HR       = [INI.DIR_OUTFILES 'DFS0HR/'];
+INI.DIR_STAGE_PNGSHR       = [INI.DIR_OUTFILES 'DFS0HR_pngs/'];
+INI.STAGEHR_LATEX_FILENAME = [INI.DIR_OUTFILES 'STAGE_HR.tex'];
 INI.STAGEHR_LATEX_HEADER   = 'Hourly Water Level Statistics';
 INI.STAGEHR_LATEX_RELATIVE_PNG_PATH = './DFS0HR_pngs/';
 
 
+% -------------------------------------------------------------------------
 % Location of ENPMS library
+% -------------------------------------------------------------------------
 INI.MATLAB_SCRIPTS = '../ENPMS/';
 
+% -------------------------------------------------------------------------
 % Other options (0 = NO, 1 = YES)
+% -------------------------------------------------------------------------
 INI.DELETE_EXISTING_DFS0 = 1;
 
+% -------------------------------------------------------------------------
 % Location of blank figure
-INI.BLANK_PNG = '../../ENP_TOOLS_Sample_Input/Data_Common/blank.png';
+% -------------------------------------------------------------------------
+INI.BLANK_PNG = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Data_Common/blank.png';
 
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------

--- a/PRE_PROCESSING/D04_generate_BC2D_H_OL.m
+++ b/PRE_PROCESSING/D04_generate_BC2D_H_OL.m
@@ -1,5 +1,7 @@
 function D04_generate_BC2D_H_OL()
 
+fprintf('\n *** THIS SCRIPT IS CURRENTLY NOT WORKING ***\n\n');
+
 % -------------------------------------------------------------------------
 % path string of ROOT Directory = DRIVE:/GIT/ENP_TOOLS MAIN Directory = PRE_PROCESSING
 % -------------------------------------------------------------------------

--- a/PRE_PROCESSING/D05_generate_BC2D_H_SZ.m
+++ b/PRE_PROCESSING/D05_generate_BC2D_H_SZ.m
@@ -1,5 +1,7 @@
 function D05_generate_BC2D_H_SZ() 
 
+fprintf('\n *** THIS SCRIPT IS CURRENTLY NOT WORKING ***\n\n');
+
 % -------------------------------------------------------------------------
 % path string of ROOT Directory = DRIVE:/GIT/ENP_TOOLS MAIN Directory = PRE_PROCESSING
 % -------------------------------------------------------------------------

--- a/PRE_PROCESSING/D06_generateObservedMatlab.m
+++ b/PRE_PROCESSING/D06_generateObservedMatlab.m
@@ -1,4 +1,7 @@
 function D06_generateObservedMatlab()
+
+fprintf('\n *** THIS SCRIPT IS CURRENTLY NOT WORKING ***\n\n');
+
 % This function creates MATLAB data file with
 %observed data
 %   This function reads sheet OBSERVED_DATA_MODEL/ALL_STATION_DATA and the

--- a/PRE_PROCESSING/D07_map_OBSERVED_DFE.m
+++ b/PRE_PROCESSING/D07_map_OBSERVED_DFE.m
@@ -17,21 +17,38 @@ function D07_map_OBSERVED_DFE()
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------
 
+% -------------------------------------------------------------------------
 % Location of ENPMS library
+% -------------------------------------------------------------------------
 INI.MATLAB_SCRIPTS = '../ENPMS/';
 
+% -------------------------------------------------------------------------
 % Location of station metadata file (this is the DFE station table)
-DFE_STATION_DATA_FILE = '../../ENP_TOOLS_Sample_Input/Data_Common/dfe_station_table.txt';
+% -------------------------------------------------------------------------
+DFE_STATION_DATA_FILE = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Data_Common/dfe_station_table.txt';
 
+% -------------------------------------------------------------------------
 %LOAD directory locations and list PNG directory options
-INI.DIR_FLOW_DFS0 = '../../ENP_TOOLS_Sample_Input/Obs_Data_Processed/FLOW/';
-INI.DIR_STAGE_DFS0 = '../../ENP_TOOLS_Sample_Input/Obs_Data_Processed/STAGE/';
+% -------------------------------------------------------------------------
+% use these for unit testing
+INI.DIR_FLOW_DFS0 = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Obs_Data_Processed/FLOW/';
+INI.DIR_STAGE_DFS0 = '../../ENP_FILES/ENP_TOOLS_Sample_Input/Obs_Data_Processed/STAGE/';
+INI.DIR_FLOW_DFS0_OUT = '../../ENP_TOOLS_Output/D07_map_OBSERVED_DFE_output/Obs_Data_Processed/FLOW/';
+INI.DIR_STAGE_DFS0_OUT = '../../ENP_TOOLS_Output/D07_map_OBSERVED_DFE_output/Obs_Data_Processed/STAGE/';
+
+% use these for sequential testing
+%INI.DIR_FLOW_DFS0 = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/FLOW/';
+%INI.DIR_STAGE_DFS0 = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/STAGE/';
+%INI.DIR_FLOW_DFS0_OUT = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/FLOW/';
+%INI.DIR_STAGE_DFS0_OUT = '../../ENP_TOOLS_Output_Sequential/Obs_Data_Processed/STAGE/';
 
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------
 % END USER INPUT
 % -------------------------------------------------------------------------
 % -------------------------------------------------------------------------
+mkdir(char(INI.DIR_FLOW_DFS0_OUT));
+mkdir(char(INI.DIR_STAGE_DFS0_OUT));
 
 try
     addpath(genpath(INI.MATLAB_SCRIPTS));
@@ -54,7 +71,7 @@ for DType_Flag = {'Discharge','WaterLevel'}
         for ii = 1: length(DFS0_TYPE)
             DIR_FILTER = [INI.DIR_FLOW_DFS0 DFS0_TYPE{ii} '_pngs/'];
             FILE_FILTER = [DIR_FILTER '*.png']; % list only files with extension *.dat
-            KML_FILE = [INI.DIR_FLOW_DFS0 char(DType_Flag) '.' DFS0_TYPE{ii} '.kml'];
+            KML_FILE = [INI.DIR_FLOW_DFS0_OUT char(DType_Flag) '.' DFS0_TYPE{ii} '.kml'];
             fid = fopen(char(KML_FILE),'w');
             fprintf(fid,'<?xml version="1.0" encoding="UTF-8"?><kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">');
             fprintf(fid,'\n<Folder><name>PreProcessing Analysis: %s-%s</name><open>1</open>', char(DType_Flag), DFS0_TYPE{ii});
@@ -85,7 +102,7 @@ for DType_Flag = {'Discharge','WaterLevel'}
         fprintf('\n');
         for ii = 1: length(DFS0_TYPE)
             FILE_FILTER = [INI.DIR_STAGE_DFS0 DFS0_TYPE{ii} '_pngs/*.png']; % list only files with extension *.dat
-            KML_FILE = [INI.DIR_STAGE_DFS0 char(DType_Flag) '.' DFS0_TYPE{ii} '.kml'];
+            KML_FILE = [INI.DIR_STAGE_DFS0_OUT char(DType_Flag) '.' DFS0_TYPE{ii} '.kml'];
             fid = fopen(char(KML_FILE),'w');
             fprintf(fid,'<?xml version="1.0" encoding="UTF-8"?><kml xmlns="http://www.opengis.net/kml/2.2" xmlns:gx="http://www.google.com/kml/ext/2.2" xmlns:kml="http://www.opengis.net/kml/2.2" xmlns:atom="http://www.w3.org/2005/Atom">');
             fprintf(fid,'\n<Folder><name>PreProcessing Analysis: %s-%s</name><open>1</open>', char(DType_Flag), DFS0_TYPE{ii});


### PR DESCRIPTION
Changed input and output directory locations on working scripts to point
to new file location in new master directory called ENP_FILES.

Changed scripts so they would not overwrite any files in
ENP_TOOLS_Sample_Input. This should now be read only.

Changed scripts to have two testing options - one is a 'unit' test where
the script will read only from files in ENP_TOOLS_Sample_Input and write
only to it's own subdirectory in ENP_TOOLS_Output. The second is a
'sequential' test where the input and output directories are the same
files, and the output of one script can be used as the input to the next
script to test the scripts work together (I/O directory is calles
'ENP_TOOLS_Output_Sequential').

Although not part of the commit, I added two output directories to
ENP_FILES that have the current expected output of the scripts, that the
user can compare their output against to insure they are working
correctly.

For scripts that are not working at the moment, I added a print message
that the script is not currently working that will appear first on the
output screen.