### PR TITLE
Data correction Issue6

### DIFF
--- a/ANALYSIS_TEMPLATE/ANALYSIS_COMPARE.m
+++ b/ANALYSIS_TEMPLATE/ANALYSIS_COMPARE.m
@@ -126,7 +126,7 @@ INI.INCLUDE_OBSERVED      = 1; % Include observed in the output figs and tables.
 INI.INCLUDE_COMPUTED      = 1; % Include computed in the output figs and tables.
 INI.LATEX_REPORT_BY_AREA  = 1; % The latex report lists stations by area 
 INI.DEBUG                 = 1; % Set this to 1 to generate extra output for debugging
-
+INI.Dfs2Domain = ''; % File location of model Domain dfs2 file.
 %---------------------------------------------------------------------
 %---------------------------------------------------------------------
 %  END USER DEFINITIONS

--- a/ANALYSIS_TEMPLATE/generateComputedMatlab.m
+++ b/ANALYSIS_TEMPLATE/generateComputedMatlab.m
@@ -122,7 +122,7 @@ INI.PLOT_COMPUTED = 1; % The user does not plot computed data
 INI.PLOT_COMPUTED = 0; %  (DEFAULT) The user plots computed data 
 
 INI.DEBUG = 0; % go in debug mdoe to executed ebug statements
-
+INI.Dfs2Domain = ''; % File location of model Domain dfs2 file.
 %---------------------------------------------------------------------
 % END OF USER INPUT: start extraction
 %---------------------------------------------------------------------

--- a/ENPMS/LIB/util/readDomainGridCodes.m
+++ b/ENPMS/LIB/util/readDomainGridCodes.m
@@ -1,0 +1,17 @@
+function DATA = readDomainGridCodes(FILE_NAME)
+dmi = NET.addAssembly('DHI.Mike.Install');
+if (~isempty(dmi))
+    DHI.Mike.Install.MikeImport.SetupLatest({DHI.Mike.Install.MikeProducts.MikeCore});
+end
+NET.addAssembly('C:\Program Files (x86)\DHI\2019\bin\x64\DHI.Generic.MikeZero.DFS.dll');
+NET.addAssembly('C:\Program Files (x86)\DHI\2019\bin\x64\DHI.Generic.MikeZero.EUM.dll');
+import DHI.Generic.MikeZero.DFS.*;
+import DHI.Generic.MikeZero.DFS.dfs123.*;
+import DHI.Generic.MikeZero.*
+dfs2File  = DfsFileFactory.Dfs2FileOpen(FILE_NAME);
+DATA.V = (double(dfs2File.ReadItemTimeStep(1,0).To2DArray()))';
+DATA.Rows = dfs2File.SpatialAxis.YCount;
+DATA.Cols = dfs2File.SpatialAxis.XCount;
+DATA.saxis= dfs2File.SpatialAxis;
+dfs2File.Close();
+end

--- a/ENPMS/LIB/util/readFileCompCoord.m
+++ b/ENPMS/LIB/util/readFileCompCoord.m
@@ -5,6 +5,7 @@ function INI = readFileCompCoord(INI)
 
 % Create empty container
 INI.mapCompSelected = containers.Map;
+dfs2Codes = readDomainGridCodes(INI.DomainDfs2);
 
 % Read Excel spreadsheet into generic data arrays
 [NUM,TXT,RAW] = xlsread(char(INI.fileCompCoord),char(INI.XLSCOMP));
@@ -24,6 +25,23 @@ for i = 2:numRows % each row has data for a different station
         stationComputed.Z = cell2mat(RAW(i,8));
         stationComputed.I = cell2mat(RAW(i,15));
         stationComputed.J = cell2mat(RAW(i,16));
+        if(dfs2Codes.saxis.X0 ~= 0 && dfs2Codes.saxis.Y0 ~= 0)
+          % check of station indexes
+          i1= (stationComputed.X_UTM-dfs2Codes.saxis.X0)/dfs2Codes.saxis.Dx; % Converting to index
+          j1= (stationComputed.Y_UTM-dfs2Codes.saxis.Y0)/dfs2Codes.saxis.Dy; % Converting to index
+          if(abs(i1 - stationComputed.I) > 0.5 || abs(j1 - stationComputed.J) > 0.5)
+            fprintf('--- Warning: Station %s at excel row %i with a coordinate indexes of (%i , %i) is estimated as (%i , %i) based on model domain dfs2\n',...
+            char(stationComputed.STATION_NAME), i, stationComputed.I, stationComputed.J, i1, j1);
+            %stationComputed.I = i1;  
+            %stationComputed.J = j1;
+          end
+        end
+        % Here we are only accepting cells of GridCode value 1, change last condition to == 0 to accept border as well
+        if((stationComputed.I + 1 > dfs2Codes.Cols || stationComputed.I + 1 <= 0) || (stationComputed.J + 1 > dfs2Codes.Rows || stationComputed.J + 1 <= 0)...
+         || dfs2Codes.V(stationComputed.J + 1, stationComputed.I + 1) ~= 1)
+         stationComputed.I = 0;
+         stationComputed.J = 0;
+        end
         stationComputed.M11CHAIN = '';
         stationComputed.N_AREA = char(TXT(i,18));
         stationComputed.I_AREA = cell2mat(RAW(i,19));


### PR DESCRIPTION
Fixes Issue 6, where stations outside the domain were not handled correctly in edge cases and added functionality to do warning check if RoCo doesn't match what is calculated from domain dfs2 file spatial axis. Currently commented if the ability to replace station RoCo with calculated one. 